### PR TITLE
Feat: #47 - 댓글 삭제 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@storybook/react-webpack5": "^7.0.24",
     "@storybook/testing-library": "^0.0.14-next.2",
     "@types/react-datepicker": "^4.11.2",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
     "babel-plugin-named-exports-order": "^0.0.2",

--- a/src/components/mission/comment.tsx
+++ b/src/components/mission/comment.tsx
@@ -2,16 +2,25 @@ import React from 'react';
 import styled from 'styled-components';
 import COLOR from '../../constants/colors';
 import FONT from '../../constants/fonts';
+import { useRecoilState } from 'recoil';
 import { CommentProps } from '../../types/comment';
 import { ReactComponent as DeleteButton } from '../../assets/svg/DeleteButton.svg';
+import { commentState } from '../../states/commentState';
 
 const Comment = (data: CommentProps) => {
+  const [commentList, setCommentList] = useRecoilState(commentState);
+
+  const handleDelete = () => {
+    const updatedList = commentList.filter((comment) => comment.id !== data.id);
+    setCommentList(updatedList);
+  };
+
   return (
     <CommentBox>
       <Top>
         <Content style={FONT.SUBTITLE4}>{data.content}</Content>
         <DeleteBtnBox>
-          <DeleteButton />
+          <DeleteButton onClick={handleDelete} />
         </DeleteBtnBox>
       </Top>
       {data.imageUrl && <CommentImage src={data.imageUrl} alt="Comment Image" />}
@@ -65,5 +74,4 @@ const CommentImage = styled.img`
   margin-top: 10px;
   border-radius: 12px;
   border: 1px solid ${COLOR.GREEN1};
-  
 `;

--- a/src/routes/MissionPage.tsx
+++ b/src/routes/MissionPage.tsx
@@ -15,6 +15,7 @@ import { addCommentItem } from '../hooks/selector';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import { nickNameState } from '../states/nicknameState';
 import { ReactComponent as DeleteButton } from '../assets/svg/DeleteButton.svg';
+import { v4 as uuidv4 } from 'uuid';
 const dummy: MissionProps = {
   id: 0,
   title: '지금 하늘 사진 찍기',
@@ -64,7 +65,7 @@ const MissionPage = () => {
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     const newComment: CommentProps = {
-      id: 0, // 임의의 id 설정
+      id: uuidv4(),
       nickName: nickName,
       content: text,
       createdAt: getFormattedDate(new Date()),

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,5 +1,5 @@
 export interface CommentProps {
-    id: number;
+    id: string;
     content: string;
     nickName: string;
     createdAt: string;


### PR DESCRIPTION
### 🚩 관련 이슈
Feat: #47 - 댓글 삭제 구현

### 📋 PR Checklist
- [ ] 댓글 삭제를 위해 comment Id를 uuid 라이브러리를 통해 생성
- [ ] commentProps의 id 타입을 string으로 변경

### 📌 유의사항


### ✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 
